### PR TITLE
Fix classname for JdbcInsert, fix typos in code samples

### DIFF
--- a/doc/myvd.asc
+++ b/doc/myvd.asc
@@ -400,7 +400,7 @@ server.DB.chain=kerberos,db
 server.DB.nameSpace=ou=People,dc=domain,dc=com
 server.DB.weight=100
 server.DB.kerberos.className=net.sourceforge.myvd.inserts.kerberos.KerberosInterceptor
-server.DB.db.className=net.sourceforge.myvd.inserts.jdbc.JdbcInterceptor
+server.DB.db.className=net.sourceforge.myvd.inserts.jdbc.JdbcInsert
 server.DB.db.config.driver=com.db.driver.Driver
 server.DB.db.config.url=jdbc:db://server/db
 server.DB.db.config.user=user
@@ -460,7 +460,7 @@ server.DB.nameSpace=ou=People,dc=domain,dc=com
 server.DB.weight=100
 server.DB.enabled=true
 server.DB.kerberos.className=net.sourceforge.myvd.inserts.kerberos.KerberosInterceptor
-server.DB.db.className=net.sourceforge.myvd.inserts.jdbc.JdbcInterceptor
+server.DB.db.className=net.sourceforge.myvd.inserts.jdbc.JdbcInsert
 server.DB.db.config.driver=com.db.driver.Driver
 server.DB.db.config.url=jdbc:db://server/db
 server.DB.db.config.user=user
@@ -1375,7 +1375,7 @@ configuration of the insert.
 
 [width="100%",cols="34%,33%,33%",]
 |=======================================================================
-|Class Name |net.sourceforge.myvd.inserts.jdbc.JdbcInterceptor |
+|Class Name |net.sourceforge.myvd.inserts.jdbc.JdbcInsert |
 
 |Scope |Search |
 
@@ -2519,7 +2519,7 @@ following configuration
 
 [width="100%",cols="34%,33%,33%",]
 |=======================================================================
-|Class Name |net.sourceforge.myvd.inserts.jdbc.JdbcInterceptor |
+|Class Name |net.sourceforge.myvd.inserts.jdbc.JdbcInsert |
 
 |Scope |Search |
 
@@ -2622,7 +2622,7 @@ server.Root.RootDSE.config.namingContexts=ou=employees,o=mycompany,c=us
 
 server.DBEmployees.chain=DB
 server.DBEmployees.nameSpace=ou=employees,o=mycompany,c=us
-server.DBEmployees.wieght=0
+server.DBEmployees.weight=0
 server.DBEmployees.DB.className=net.sourceforge.myvd.inserts.jdbc.JdbcInsert
 server.DBEmployees.DB.config.driver=com.mysql.jdbc.Driver
 server.DBEmployees.DB.config.url=jdbc:mysql://localhost/myvdtest
@@ -2781,7 +2781,7 @@ server.Root.RootDSE.config.namingContexts=ou=employees-uid_cn,o=mycompany,c=us
 
 server.DBEmployeesUidCn.chain=CleanAttribs,MakeUID,MakeCN,DB
 server.DBEmployeesUidCn.nameSpace=ou=employees-uid_cn,o=mycompany,c=us
-server.DBEmployeesUidCn.wieght=0
+server.DBEmployeesUidCn.weight=0
 
 server.DBEmployeesUidCn.CleanAttribs.className=net.sourceforge.myvd.inserts.mapping.AttributeCleaner
 
@@ -2883,7 +2883,7 @@ server.Root.RootDSE.config.namingContexts=ou=employees,o=mycompany,c=us|ou=emplo
 
 server.DBEmployeesUidRDN.chain=CleanAttribs,SetRDN,MakeUID,MakeCN,DB
 server.DBEmployeesUidRDN.nameSpace=ou=employees-uid_rdn,o=mycompany,c=us
-server.DBEmployeesUidRDN.wieght=0
+server.DBEmployeesUidRDN.weight=0
 
 server.DBEmployeesUidRDN.CleanAttribs.className=net.sourceforge.myvd.inserts.mapping.AttributeCleaner
 


### PR DESCRIPTION
The classname listed in the docs for the JDBC insert incorrectly listed the class name for the insert as net.sourceforge.myvd.inserts.jdbc.JdbcInterceptor. I fixed it to refer to net.sourceforge.myvd.inserts.jdbc.JdbcInsert.
I also corrected "wieght" to "weight" in a couple code examples.
